### PR TITLE
GEN-64 Factor S3 uploading into dedicated class

### DIFF
--- a/lib/jiratk/s3_tools.rb
+++ b/lib/jiratk/s3_tools.rb
@@ -1,0 +1,19 @@
+# frozen-string-literal: true
+
+require 'aws-sdk-s3'
+
+# Simple wrapper for AWS S3 API.
+class S3Tools
+  def region
+    ENV['AWS_REGION']
+  end
+
+  def client(options = {})
+    options[:region] = region
+    @client ||= Aws::S3::Client.new(options)
+  end
+
+  def write(issue)
+    client.put_object(bucket: 'inventium-jira', key: issue['key'], body: issue.to_json)
+  end
+end

--- a/spec/lib/jiratk/s3_tools_spec.rb
+++ b/spec/lib/jiratk/s3_tools_spec.rb
@@ -1,0 +1,30 @@
+# frozen-string-literal: true
+
+RSpec.describe S3Tools do
+  describe '#region' do
+    let(:region) { 'foo' }
+
+    it 'finds current region' do
+      ENV['AWS_REGION'] = region
+      expect(described_class.new.region).to eq region
+    end
+
+    xit 'raises if region not specified' do
+      ENV['AWS_REGION'] = nil
+
+      expect do
+        described_class.new.region
+      end.to raise_error(Aws::Errors::MissingRegionError)
+    end
+  end
+
+  describe '#client' do
+    it 'acquires an S3 client instance' do
+      expect(described_class.new.client(stub_responses: true)).not_to be nil
+    end
+  end
+
+  describe '#write' do
+    it 'writes to s3'
+  end
+end


### PR DESCRIPTION
S3 operations are now moved to their own class.

Specs are started but deficient. It's not clear
how to unit test. "Integration" testing is by
running the script and checking the S3 bucket for
timestamps.

The end goal is to have a script which only configures,
then invokes an execution. The script should have no logic
in it at all.