### PR TITLE
GEN-69 Clean up the s3 provisioning script

### DIFF
--- a/exe/copy_from_template.rb
+++ b/exe/copy_from_template.rb
@@ -10,7 +10,7 @@ require 'fileutils'
 require 'ap'
 require 'pry'
 
-require_relative './lib/jiratk/oautherizer'
+require_relative '../lib/jiratk/oautherizer'
 
 APPLICATION_NAME = 'Drive API Ruby Quickstart'
 

--- a/exe/gem_update.rb
+++ b/exe/gem_update.rb
@@ -10,8 +10,8 @@ require 'json'
 require 'aws-sdk-s3'
 require 'csv'
 
-require_relative 'lib/jiratk/account_manager'
-require_relative 'lib/jiratk/api_helper'
+require_relative '../lib/jiratk/account_manager'
+require_relative '../lib/jiratk/api_helper'
 
 api_keys = AccountManager.new.api_keys
 USERNAME = api_keys[:jira_id]

--- a/exe/provision_s3.rb
+++ b/exe/provision_s3.rb
@@ -9,9 +9,9 @@ require 'rest-client'
 require 'json'
 require 'csv'
 
-require_relative 'lib/jiratk/account_manager'
-require_relative 'lib/jiratk/api_helper'
-require_relative 'lib/jiratk/s3_tools'
+require_relative '../lib/jiratk/account_manager'
+require_relative '../lib/jiratk/api_helper'
+require_relative '../lib/jiratk/s3_tools'
 
 api_keys = AccountManager.new.api_keys
 USERNAME = api_keys[:jira_id]
@@ -81,7 +81,13 @@ def project_list
   projects
 end
 
-# Do tasklets project first
+def path
+  @path ||= '/tmp' # or current working directory tmp, or whatever
+end
+
+# Do tasklets project first, then consider adding capability
+# to write an issue as a fixture. Adding a write via dependency
+# injection would be helpful.
 def batch_download_for(project)
   total = issue_count_for(project)
 
@@ -89,13 +95,14 @@ def batch_download_for(project)
     issues = get_issues_for(project, start_at)
     issues.each do |issue|
       puts issue['key']
-      File.open("/tmp/jira/#{issue['key']}.json", 'w') do |f|
+      # TODO: factor this out as a DI
+      File.open("#{path}/jira/#{issue['key']}.json", 'w') do |f|
         f.write(issue)
       end
     end
   end
 end
-# batch_download_for('TASKLETS')
+batch_download_for('TASKLETS')
 
 def s3
   @s3 ||= S3Tools.new
@@ -109,55 +116,13 @@ def write_to_s3
     end
   end
 end
-write_to_s3
+# write_to_s3
 
-# Next round of work is writing the files to a local directory
-# for convenience. This will help with generating csvs a lot.
-def write_to_fixtures
-  # write everything to spec/fixtures directory.
-end
-# write_to_fixtures
-
-# What we really want to do is stream the json directly from the values returned
-# from Jira. Some questions:
-# 1. Do we want to upload every issue every time?
-# 2. Or would it be better to sync instead?
-#
-# The first thing is to just get the Jira issues copied to S3. Then I can worry
-# about duplicating existing issues.
-#
-# The problem with syncing is that I do not intended to keep a local copy of
-# the Jira issues, so I'm not sure how syncing would work.
-#
-# Athena after S3 is working working.
-# I think this means turning the json into csv.
-#
-#
-# Getting json into csv means figuring out which of the json fields we want
-# to extract, then getting those fields extracted.
-# - Do we need headers?
-# - How to deal with commas ',' in fields?
-#
-# At least the following to start:
-# - key
-# - fields::issuetype::name
-# - field::timespent
-# - fields::project::name
-# - fields::resolution::name
-# - fields::assignee::displayName
-
-# Some example json, put this into a fixture file later.
-# Schedule a ticket to periodically update the fixture file
-# from collected issues.
-# TODO: Replace this with a fixture from the TASKLETS project, which will be
-# much more interesting.
-
-# require_relative './spec/fixtures/plant_5'
-# ap plant[:key]
-# ap plant.dig(:fields, :issuetype, :name)
-# ap plant.dig(:fields, :project, :name)
-# ap plant.dig(:fields, :resolution, :name)
-# ap plant.dig(:fields, :assignee, :displayName)
-# ap plant.dig(:fields, :status, :statusCategory, :name)
-# # description is going to have to have its own processor
-# ap plant.dig(:fields, :description, :content)[0][:content][0][:text]
+# TODO: rewrite script in terms of DSL:
+# configure:
+#  jira api credentials
+#  aws credentials
+#  desired activity:
+#    pull all tickets from every project
+#    upload all tickets from every project to S3
+# execute

--- a/lib/jiratk/csv_writer.rb
+++ b/lib/jiratk/csv_writer.rb
@@ -1,0 +1,49 @@
+# frozen-string-literal: true
+
+# Utilities for writing CSV files
+# What we really want to do is stream the json directly from the values returned
+# from Jira. Some questions:
+# 1. Do we want to upload every issue every time?
+# 2. Or would it be better to sync instead?
+#
+# The first thing is to just get the Jira issues copied to S3. Then I can worry
+# about duplicating existing issues.
+#
+# The problem with syncing is that I do not intended to keep a local copy of
+# the Jira issues, so I'm not sure how syncing would work.
+#
+# Athena after S3 is working working.
+# I think this means turning the json into csv.
+#
+#
+# Getting json into csv means figuring out which of the json fields we want
+# to extract, then getting those fields extracted.
+# - Do we need headers?
+# - How to deal with commas ',' in fields?
+#
+# At least the following to start:
+# - key
+# - fields::issuetype::name
+# - field::timespent
+# - fields::project::name
+# - fields::resolution::name
+# - fields::assignee::displayName
+
+# Some example json, put this into a fixture file later.
+# Schedule a ticket to periodically update the fixture file
+# from collected issues.
+# TODO: Replace this with a fixture from the TASKLETS project, which will be
+# much more interesting.
+
+# require_relative './spec/fixtures/plant_5'
+# ap plant[:key]
+# ap plant.dig(:fields, :issuetype, :name)
+# ap plant.dig(:fields, :project, :name)
+# ap plant.dig(:fields, :resolution, :name)
+# ap plant.dig(:fields, :assignee, :displayName)
+# ap plant.dig(:fields, :status, :statusCategory, :name)
+# # description is going to have to have its own processor
+# ap plant.dig(:fields, :description, :content)[0][:content][0][:text]
+class CsvWriter
+  def new; end
+end

--- a/spec/lib/jiratk/csv_writer_spec.rb
+++ b/spec/lib/jiratk/csv_writer_spec.rb
@@ -1,0 +1,7 @@
+# frozen-string-literal: true
+
+RSpec.describe CsvWriter do
+  it 'instantiates' do
+    expect(described_class.new).to_not be nil
+  end
+end


### PR DESCRIPTION
More whittling away at the s3 provisioning script
to get something very clean and easy to use.

Some next steps are factoring out the project handling
code which does the issue downloading, cleaning up the
Jira API interface, which is stupid clunky, and defining
a proto-DSL to render the provisioning script very simple.