### PR TITLE
GEN-70 Factor out project listing for Jira account

### DIFF
--- a/lib/jiratk/account_manager.rb
+++ b/lib/jiratk/account_manager.rb
@@ -10,4 +10,17 @@ class AccountManager
       jira_key: ENV['DOOLIN_JIRA_API']
     }
   end
+
+  def search_url
+    @search_url ||= 'https://doolin.atlassian.net/rest/api/3/project/search'
+  end
+
+  def project_keys
+    api_helper = ApiHelper.new(search_url)
+
+    response = api_helper.get({})
+    response_json = JSON.parse(response)
+
+    response_json['values'].map { |value| value['key'] }
+  end
 end

--- a/spec/lib/jiratk/acccount_manager_spec.rb
+++ b/spec/lib/jiratk/acccount_manager_spec.rb
@@ -1,0 +1,23 @@
+# frozen-string-literal: true
+
+RSpec.describe AccountManager do
+  it 'instantiates' do
+    expect(described_class.new).not_to be nil
+  end
+
+  describe '#api_keys' do
+    it 'acquires API keys for Jira connection'
+  end
+
+  describe '#search_url' do
+    it 'provides jira project API search URL' do
+      expected = 'https://doolin.atlassian.net/rest/api/3/project/search'
+
+      expect(described_class.new.search_url).to eq expected
+    end
+  end
+
+  describe '#project_keys' do
+    it 'lists keys for all projects'
+  end
+end


### PR DESCRIPTION
Projects in Jira are associated with accounts, so it
makes sense to have a method for listing project keys
as a part of the class which manages accounts.

A few other minor cleanups were done, some TODO items
added, and a few more specs and stubbed specs.