### PR TITLE
GEN-73 Modify lib/jiratk.rb to manage all relevant files

### DIFF
--- a/exe/copy_from_template.rb
+++ b/exe/copy_from_template.rb
@@ -10,7 +10,7 @@ require 'fileutils'
 require 'ap'
 require 'pry'
 
-require_relative '../lib/jiratk/oautherizer'
+require_relative '../lib/jiratk'
 
 APPLICATION_NAME = 'Drive API Ruby Quickstart'
 
@@ -22,6 +22,8 @@ fileservice = Google::Apis::DriveV3::DriveService.new
 fileservice.client_options.application_name = APPLICATION_NAME
 fileservice.authorization = FileAuth.new.authorize
 
+# Make a copy and rename in the same folder
+# https://docs.google.com/spreadsheets/d/1kgLR6IMDDrhy2pgZy106tiSoSbCY0a105xRfK4t7jU8/edit#gid=1342191115
 source_id = '1kgLR6IMDDrhy2pgZy106tiSoSbCY0a105xRfK4t7jU8'
 new_file = fileservice.copy_file(source_id)
 fileservice.update_file(new_file.id, Google::Apis::DriveV3::File.new(name: '1 AAA Estimation'))

--- a/exe/copy_to_new_spreadsheet.rb
+++ b/exe/copy_to_new_spreadsheet.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen-string-literal: true
 
+# This script doesn't really work, should probably delete it.
+
 require 'google/apis/drive_v3'
 require 'google/apis/sheets_v4'
 require 'googleauth'
@@ -10,7 +12,7 @@ require 'fileutils'
 require 'ap'
 require 'pry'
 
-require_relative '../lib/jiratk/oautherizer'
+require_relative '../lib/jiratk'
 
 APPLICATION_NAME = 'Drive API Ruby Quickstart'
 

--- a/exe/gem_update.rb
+++ b/exe/gem_update.rb
@@ -10,8 +10,7 @@ require 'json'
 require 'aws-sdk-s3'
 require 'csv'
 
-require_relative '../lib/jiratk/account_manager'
-require_relative '../lib/jiratk/api_helper'
+require_relative '../lib/jiratk'
 
 api_keys = AccountManager.new.api_keys
 USERNAME = api_keys[:jira_id]
@@ -102,7 +101,7 @@ ticket = OpenStruct.new(
   project_key: 'SCRUM',
   issuetype_name: 'Task',
   gem: 'rubocop',
-  version: '1.0.42'
+  version: '1.3.1'
 )
 
 params = GemIssue.new(ticket).to_h

--- a/exe/provision_s3.rb
+++ b/exe/provision_s3.rb
@@ -2,11 +2,7 @@
 
 # frozen-string-literal: true
 
-# TODO: `require '../lib/jiratk'` and have all these loaded in that file.
-require_relative '../lib/jiratk/account_manager'
-require_relative '../lib/jiratk/api_helper'
-require_relative '../lib/jiratk/s3_tools'
-require_relative '../lib/jiratk/project'
+require_relative '../lib/jiratk'
 
 def account_manager
   @account_manager ||= AccountManager.new
@@ -22,6 +18,7 @@ PASSWORD = api_keys[:jira_key]
 # puts "issue count for GEN project: #{Project.issue_count_for('GEN')}"
 # puts "list of keys for PLANTS project: #{Project.list_issues_for('PLANTS')}"
 # Project.batch_download_for('PLANTS')
+# exit
 
 def write_all_issues_to_s3
   s3 = S3Tools.new

--- a/exe/provision_templates.rb
+++ b/exe/provision_templates.rb
@@ -3,14 +3,7 @@
 
 require 'fileutils'
 
-require 'ap'
-require 'pry'
-
-require_relative '../lib/jiratk/oautherizer'
-require_relative '../lib/jiratk/account_manager'
-require_relative '../lib/jiratk/api_helper'
-require_relative '../lib/jiratk/assessment_ticket'
-require_relative '../lib/jiratk/template_cloner'
+require_relative '../lib/jiratk'
 
 # TODO: step 4 from https://docs.google.com/spreadsheets/d/1JD10EqecIqj8qB-kQTeCBPjxDOkpG-BZvdqX_ukX6Gs/edit#gid=0
 # Create a dedicated class for provisioning these tickets, which instantiates with an

--- a/lib/jiratk.rb
+++ b/lib/jiratk.rb
@@ -1,1 +1,5 @@
 # frozen-string-literal: true
+
+Dir[File.join(File.dirname(__FILE__), '.', 'jiratk', '**.rb')].sort.each do |f|
+  require f
+end

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -1,0 +1,21 @@
+# Temporary script for manual testing.
+# Uncomment each of the following to manually test.
+
+# Check whether files are updated on S3, then
+# check the various method results from Project
+# which need to be done by uncommenting.
+# ./exe/provision_s3.rb
+
+# Make a copy of the software_estimation_template and
+# rename it in the same folder:
+# ./exe/copy_from_template.rb
+
+# This one doesn't really work.
+# ./exe/copy_to_new_spreadsheet.rb
+
+# Test ticket creation
+# https://doolin.atlassian.net/secure/RapidBoard.jspa?projectKey=SCRUM&rapidView=1&view=planning.nodetail
+# ./exe/gem_update.rb
+
+# This is a big one, copies templates and renames them:
+# ./exe/provision_templates.rb


### PR DESCRIPTION
Simplify the `require` for operating the scripts.

To ensure all the script remained working after the change,
a sh script with comments was added. In the future, all
these tests will be semi-automated.