### PR TITLE
GEN-74 Upload all Jira issues to S3

### DIFF
--- a/exe/provision_s3.rb
+++ b/exe/provision_s3.rb
@@ -14,20 +14,15 @@ PASSWORD = api_keys[:jira_key]
 
 # TODO: Create a "fake" project on Jira, prepopulate with fake issues in various
 # states, then use that project with those issues to test the following:
-#
 # puts "issue count for GEN project: #{Project.issue_count_for('GEN')}"
-# puts "list of keys for PLANTS project: #{Project.list_issues_for('PLANTS')}"
 # Project.batch_download_for('PLANTS')
 # exit
 
 def write_all_issues_to_s3
-  s3 = S3Tools.new
+  writer = S3Tools.new.method(:write)
 
   account_manager.project_keys.each do |project|
-    issues = Project.get_issues_for(project, 0)
-    issues.each do |issue|
-      s3.write(issue)
-    end
+    Project.batch_download_for(project, writer)
   end
 end
 write_all_issues_to_s3

--- a/lib/jiratk/project.rb
+++ b/lib/jiratk/project.rb
@@ -41,33 +41,21 @@ class Project
     response_json['total']
   end
 
-  def self.list_issues_for(project)
-    issues = get_issues_for(project, 0)
-    issues.each do |issue|
-      puts issue['key']
-      # File.open("/tmp/jira/#{issue['key']}.json","w") do |f|
-      #   f.write(issue)
-      # end
+  def self.file_writer(issue, path = '/tmp')
+    File.open("#{path}/jira/#{issue['key']}.json", 'w') do |f|
+      f.write(issue)
     end
-    issues
   end
 
-  def self.path
-    @path ||= '/tmp' # or current working directory tmp, or whatever
-  end
-
-  def self.batch_download_for(project)
+  def self.batch_download_for(project, writer = method(:file_writer))
     total = issue_count_for(project)
 
     (0..total).step(STEP).each do |start_at|
       issues = get_issues_for(project, start_at)
+
       issues.each do |issue|
         puts issue['key']
-        # TODO: factor this out as a DI, should take an S3 writer
-        # and a File writer
-        File.open("#{path}/jira/#{issue['key']}.json", 'w') do |f|
-          f.write(issue)
-        end
+        writer.call(issue)
       end
     end
   end

--- a/spec/lib/jiratk/project_spec.rb
+++ b/spec/lib/jiratk/project_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe Project do
     it 'counts the project issues'
   end
 
-  describe '.path' do
-    it 'stashes path'
-  end
-
-  describe '.list_issues_for' do
-    it 'lists the issues'
-  end
-
   describe '.batch_download_for' do
     it 'downloads all issues for a project'
   end


### PR DESCRIPTION
"Make the change easy then make the easy change"

This is a great example of the above. Getting all the Jira
issues for a project has to be done in batches of maximum 50.
Previous commits worked out the structure for how this ought
to work. This commit implements batch downloading for all the
projects, passing in where the issues are written as a `writer`
callback.