### PR TITLE
GEN-76 add spec to ApiHelper#new

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,5 @@ gem 'rubocop'
 gem 'runbook', '~> 1.0'
 
 gem 'vcr', '~> 6.0'
+
+gem 'webmock', '~> 3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     contracts (0.16.0)
+    crack (0.4.4)
     cucumber (5.2.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 8.0, >= 8.0.1)
@@ -108,6 +109,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
+    hashdiff (1.0.1)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -238,6 +240,10 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     vcr (6.0.0)
+    webmock (3.10.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     wisper (2.0.1)
     zeitwerk (2.4.1)
 
@@ -258,6 +264,7 @@ DEPENDENCIES
   rubocop
   runbook (~> 1.0)
   vcr (~> 6.0)
+  webmock (~> 3.10)
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/exe/copy_from_template.rb
+++ b/exe/copy_from_template.rb
@@ -26,4 +26,4 @@ fileservice.authorization = FileAuth.new.authorize
 # https://docs.google.com/spreadsheets/d/1kgLR6IMDDrhy2pgZy106tiSoSbCY0a105xRfK4t7jU8/edit#gid=1342191115
 source_id = '1kgLR6IMDDrhy2pgZy106tiSoSbCY0a105xRfK4t7jU8'
 new_file = fileservice.copy_file(source_id)
-fileservice.update_file(new_file.id, Google::Apis::DriveV3::File.new(name: '1 AAA Estimation'))
+fileservice.update_file(new_file.id, Google::Apis::DriveV3::File.new(name: '1 AAA Estimation [deleteme]'))

--- a/exe/gem_update.rb
+++ b/exe/gem_update.rb
@@ -2,22 +2,11 @@
 
 # frozen-string-literal: true
 
-require 'pp'
-require 'ap'
-require 'pry'
-require 'rest-client'
-require 'json'
-require 'aws-sdk-s3'
-require 'csv'
 require 'runbook'
-
 require_relative '../lib/jiratk'
 
-api_keys = AccountManager.new.api_keys
-USERNAME = api_keys[:jira_id]
-PASSWORD = api_keys[:jira_key]
-
 # Helper class for keep in the json generation under control.
+# TODO: Move to an Issue class
 class Issue
   def initialize(ticket)
     @project_key = ticket.project_key
@@ -100,6 +89,8 @@ require 'ostruct'
 
 # rubocop:disable Metrics/BlockLength
 runbook = Runbook.book 'Update gem' do
+  # TODO: add setup section for instantiating ApiHelper
+
   section 'collect gem information' do
     step 'collect project name' do
       ask 'what project?', into: :project
@@ -123,9 +114,13 @@ runbook = Runbook.book 'Update gem' do
         params = GemIssue.new(ticket).to_h
         confirm "Gem update parameters: #{params}"
 
+        api_keys = AccountManager.new.api_keys
+        username = api_keys[:jira_id]
+        password = api_keys[:jira_key]
+        api_helper = ApiHelper.new(username, password)
         api_url = 'https://doolin.atlassian.net/rest/api/2/issue/'
-        api_helper = ApiHelper.new(api_url)
-        api_helper.post(params)
+
+        api_helper.post(api_url, params)
       end
     end
   end

--- a/exe/provision_s3.rb
+++ b/exe/provision_s3.rb
@@ -9,20 +9,21 @@ def account_manager
 end
 
 api_keys = account_manager.api_keys
-USERNAME = api_keys[:jira_id]
-PASSWORD = api_keys[:jira_key]
+username = api_keys[:jira_id]
+password = api_keys[:jira_key]
+@api_helper = ApiHelper.new(username, password)
 
 # TODO: Create a "fake" project on Jira, prepopulate with fake issues in various
 # states, then use that project with those issues to test the following:
-# puts "issue count for GEN project: #{Project.issue_count_for('GEN')}"
-# Project.batch_download_for('PLANTS')
+# puts "issue count for GEN project: #{Project.issue_count_for(@api_helper, 'GEN')}"
+# Project.batch_download_for(@api_helper, 'PLANTS')
 # exit
 
 def write_all_issues_to_s3
   writer = S3Tools.new.method(:write)
 
-  account_manager.project_keys.each do |project|
-    Project.batch_download_for(project, writer)
+  account_manager.project_keys(@api_helper).each do |project|
+    Project.batch_download_for(@api_helper, project, writer)
   end
 end
 write_all_issues_to_s3

--- a/exe/provision_templates.rb
+++ b/exe/provision_templates.rb
@@ -24,10 +24,10 @@ fileservice.authorization = FileAuth.new.authorize
 # elsewhere and not have the following block of code cluttering
 # up the file.
 api_keys = AccountManager.new.api_keys
-USERNAME = api_keys[:jira_id]
-PASSWORD = api_keys[:jira_key]
+username = api_keys[:jira_id]
+password = api_keys[:jira_key]
 api_url = 'https://doolin.atlassian.net/rest/api/2/issue/'
-api_helper = ApiHelper.new(api_url)
+api_helper = ApiHelper.new(username, password)
 
 # Everything above here needs to go into its own class.
 # Below here is where the operator action occurs.
@@ -62,7 +62,7 @@ ids.each do |id|
   )
 
   params = AssessmentTicket.new(params).to_h
-  api_helper.post(params)
+  api_helper.post(api_url, params)
 
   puts tc.url
 end

--- a/lib/jiratk/account_manager.rb
+++ b/lib/jiratk/account_manager.rb
@@ -15,10 +15,10 @@ class AccountManager
     @search_url ||= 'https://doolin.atlassian.net/rest/api/3/project/search'
   end
 
-  def project_keys
-    api_helper = ApiHelper.new(search_url)
+  def project_keys(api_helper)
+    # api_helper = ApiHelper.new(search_url)
 
-    response = api_helper.get({})
+    response = api_helper.get(search_url, {})
     response_json = JSON.parse(response)
 
     response_json['values'].map { |value| value['key'] }

--- a/lib/jiratk/api_helper.rb
+++ b/lib/jiratk/api_helper.rb
@@ -4,30 +4,32 @@ require 'rest-client'
 
 # Add class documentation
 class ApiHelper
-  def initialize(api_url)
-    @api_url = api_url
-    @resource = RestClient::Resource.new(
-      api_url, user: USERNAME, password: PASSWORD
-    )
+  def initialize(username = nil, password = nil)
+    @username = username
+    @password = password
   end
 
-  def get(params)
-    @resource.get(accept: :json, params: params) do |resp, req, res, &block|
+  def get(url, params)
+    resource = RestClient::Resource.new(
+      url, user: @username, password: @password
+    )
+
+    resource.get(accept: :json, params: params) do |resp, req, res, &block|
       return resp if (200..499).include? resp.code
 
       resp.return!(req, res, &block)
     end
   end
 
-  def post_client(params)
+  def post_client(url, params)
     RestClient::Request.new(
-      url: @api_url, user: USERNAME, password: PASSWORD, payload: params.to_json, method: :post,
+      url: url, user: @username, password: @password, payload: params.to_json, method: :post,
       headers: { content_type: 'application/json' }
     )
   end
 
-  def post(params)
-    post_client(params).execute do |response, request, _result, &block|
+  def post(url, params)
+    post_client(url, params).execute do |response, request, _result, &block|
       puts "RESPONSE: #{response.code}"
       puts "RESPONSE BODY: #{response.body}"
 

--- a/lib/jiratk/project.rb
+++ b/lib/jiratk/project.rb
@@ -11,32 +11,28 @@ class Project
 
   # `startAt` works in reverse order: it indexes the latest
   # ticket at 0, and works backwards from that.
-  def self.get_issues_for(project, start_at)
+  def self.get_issues_for(api_helper, project, start_at)
     query = {
       jql: "project = \"#{project}\"",
       startAt: start_at.to_s,
       maxResults: STEP
     }
 
-    api_helper = ApiHelper.new(search_url)
-
-    response = api_helper.get(query)
+    response = api_helper.get(search_url, query)
     response_json = JSON.parse(response)
     response_json['issues']
   end
 
   # setting maxResults: 0 returns just metadata which will
   # contain `total`, the number of issues in a project.
-  def self.issue_count_for(project)
+  def self.issue_count_for(api_helper, project)
     query = {
       jql: "project = \"#{project}\"",
       startAt: 0,
       maxResults: 0
     }
 
-    api_helper = ApiHelper.new(search_url)
-
-    response = api_helper.get(query)
+    response = api_helper.get(search_url, query)
     response_json = JSON.parse(response)
     response_json['total']
   end
@@ -47,11 +43,11 @@ class Project
     end
   end
 
-  def self.batch_download_for(project, writer = method(:file_writer))
-    total = issue_count_for(project)
+  def self.batch_download_for(api_helper, project, writer = method(:file_writer))
+    total = issue_count_for(api_helper, project)
 
     (0..total).step(STEP).each do |start_at|
-      issues = get_issues_for(project, start_at)
+      issues = get_issues_for(api_helper, project, start_at)
 
       issues.each do |issue|
         puts issue['key']

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -10,12 +10,27 @@
 # rename it in the same folder:
 # ./exe/copy_from_template.rb
 
-# This one doesn't really work.
+# This one doesn't really work, skip it for now.
 # ./exe/copy_to_new_spreadsheet.rb
 
 # Test ticket creation
 # https://doolin.atlassian.net/secure/RapidBoard.jspa?projectKey=SCRUM&rapidView=1&view=planning.nodetail
 # ./exe/gem_update.rb
 
-# This is a big one, copies templates and renames them:
-# ./exe/provision_templates.rb
+# This is a big one, copies templates and renames them.
+# $ ./exe/provision_templates.rb
+#
+# The results should look like this:
+# RESPONSE: 201
+# RESPONSE BODY: {"id":"10373","key":"SCRUM-82","self":"https://doolin.atlassian.net/rest/api/2/issue/10373"}
+# https://docs.google.com/spreadsheets/d/1ZfXxxvJot4adkUEG5Jfzvr9usVE2Kny1DuA9Mt_kOFc/edit#gid=0
+# RESPONSE: 201
+# RESPONSE BODY: {"id":"10374","key":"SCRUM-83","self":"https://doolin.atlassian.net/rest/api/2/issue/10374"}
+# https://docs.google.com/spreadsheets/d/1yBmlm9TLkt-N8ggmKAV6kYEop-ue4M-rRRyGtgTRE5Y/edit#gid=0
+# RESPONSE: 201
+# RESPONSE BODY: {"id":"10375","key":"SCRUM-84","self":"https://doolin.atlassian.net/rest/api/2/issue/10375"}
+# https://docs.google.com/spreadsheets/d/1otJV3xBSk0w6NGGCVL3ufrjsvVbBrxathKKBy-BHcJo/edit#gid=0
+#
+# Cleaning up:
+# 1. remove the tickets from the SCRUM board: https://doolin.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=SCRUM&view=planning.nodetail&issueLimit=100
+# 2. remove the files from drive: https://drive.google.com/drive/u/2/recent

--- a/spec/lib/jiratk/api_helper_spec.rb
+++ b/spec/lib/jiratk/api_helper_spec.rb
@@ -1,0 +1,11 @@
+# frozen-string-literal: true
+
+RSpec.describe ApiHelper do
+  it 'instantiates' do
+    api_keys = AccountManager.new.api_keys
+    username = api_keys[:jira_id]
+    password = api_keys[:jira_key]
+
+    expect(described_class.new(username, password)).to_not be nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,16 @@
 # frozen-string-literal: true
 
+require 'vcr'
+
 Dir[File.join(File.dirname(__FILE__), '..', 'lib', 'jiratk', '**.rb')].sort.each do |f|
   require f
 end
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/cassettes'
+  config.hook_into :webmock
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
This turned into a major refactor necessary to support
rational API testing, and reuse for that matter.

VCR wasn't actually needed for this commit. In a production
system, I'd probably take it out and use it as the basis of
the next ticket, which explicitly calls the Jira API.