### PR TITLE
GEN-166 fix requires for jiratk

### DIFF
--- a/lib/jiratk.rb
+++ b/lib/jiratk.rb
@@ -1,5 +1,10 @@
 # frozen-string-literal: true
 
-Dir[File.join(File.dirname(__FILE__), '.', 'jiratk', '**.rb')].sort.each do |f|
-  require f
-end
+# Dir[File.join(File.dirname(__FILE__), '.', 'jiratk', '**.rb')].sort.each do |f|
+#   require f
+# end
+
+require_relative './jiratk/account_manager'
+require_relative './jiratk/api_helper'
+require_relative './jiratk/s3_tools'
+require_relative './jiratk/project'


### PR DESCRIPTION
For some reason, which I do not recall, the `require`
syntax broke. This commit fixes that. The changes
were made weeks ago, were never committed.