### PR TITLE
GEN-92 Document Atlassian Rovo MCP in AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.1'
+          bundler-cache: true
+
+      - name: Bundler audit
+        run: |
+          bundle exec bundle audit update
+          bundle exec bundle audit check
+
+      - name: RSpec
+        run: bundle exec rspec
+
+      - name: RuboCop
+        run: bundle exec rubocop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,9 @@ Guidance for AI agents working in this repo.
 | Install deps | `bundle install` |
 | Tests | `bundle exec rspec` or `rake` (default task is spec) |
 | Lint | `bundle exec rubocop` |
-| Run an exe | `bundle exec exe/<name>` (e.g. `bundle exec exe/provision_s3`)
+| Security | `bundle exec bundle audit check` (after `bundle audit update`) |
+| Run an exe | `bundle exec exe/<name>` (e.g. `bundle exec exe/provision_s3`) |
+| Jira (MCP) | Atlassian Rovo MCP — configure per IDE; OAuth on first use |
 
 ## Conventions
 
@@ -54,5 +56,5 @@ When suggesting or writing commit messages, read this section and include the Ji
 
 ## Other
 
-- CI: `.github/workflows/` (PR title linter only). Semaphore disabled.
+- CI: `.github/workflows/ci.yml` (bundle audit, rspec, rubocop); PR title linter.
 - Specs use VCR/webmock (see `spec/cassettes/`). Keep API and env details out of committed secrets.

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :google, :default do
 end
 
 group :development do
+  gem 'bundler-audit', require: false
   gem 'debug'
   gem 'flay'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     cgi (0.5.1)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
@@ -286,11 +289,13 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   awesome_print
   aws-sdk-athena
   aws-sdk-s3
+  bundler-audit
   cgi
   csv
   debug


### PR DESCRIPTION
## Summary

- Document Atlassian Rovo MCP in `AGENTS.md` commands table
- Config lives in `~/.cursor/mcp.json` (`npx mcp-remote` + OAuth)

https://doolin.atlassian.net/browse/GEN-92

Part of GEN-92 (bundle audit + GitHub Actions); this commit is agent/MCP setup only.

## Test plan

- [x] MCP OAuth connected to `doolin.atlassian.net`
- [x] `getJiraIssue` smoke test for GEN-92 via MCP
- [ ] Remaining GEN-92 work: bundle-audit + GitHub Actions (separate commits on this branch)

Made with [Cursor](https://cursor.com)