### PR TITLE
GEN-723 Add PAH-only marisu-jira CLI for Marisu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ https://doolin.atlassian.net/browse/GEN-<number>
 
 When suggesting or writing commit messages, read this section and include the Jira URL.
 
+Ensure credit: Coauthored by Ron via <client> <model>
+
 ## Other
 
 - CI: `.github/workflows/ci.yml` (bundle audit, rspec, rubocop); PR title linter.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '4.0.1'
+ruby '>= 4.0.1'
 
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ From the project root (or via `bundle exec`):
 | `copy_to_new_spreadsheet` | Copy data to a new Google Sheet |
 | `gem_update` | Update gem dependencies |
 | `provision_s3` | Provision S3 resources |
+| `marisu_jira` | PAH-only Jira reads for Marisu agent |
 | `provision_templates` | Provision Jira templates |
 
 ## Development

--- a/exe/marisu_jira
+++ b/exe/marisu_jira
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Resolve jiratk root when invoked via ~/scripts/bin symlink or bundle exec.
+# realpath: symlink from ~/scripts/bin must resolve to jiratk/exe/
+root = File.expand_path('..', File.dirname(File.realpath(__FILE__))) # rubocop:disable Style/Dir
+$LOAD_PATH.unshift(File.join(root, 'lib')) unless $LOAD_PATH.include?(File.join(root, 'lib'))
+
+# Marisu only needs rest-client — not the full jiratk Gemfile (AWS, Google, etc.).
+require 'bundler/inline'
+gemfile do
+  source 'https://rubygems.org'
+  gem 'rest-client', '~> 2.1'
+end
+
+require 'json'
+require 'jiratk/account_manager'
+require 'jiratk/api_helper'
+require 'jiratk/pah/error'
+require 'jiratk/pah/issue_key'
+require 'jiratk/pah/jql'
+require 'jiratk/pah/client'
+
+# PAH-only Jira CLI for Marisu (reads).
+module MarisuJiraCli
+  module_function
+
+  def run(argv)
+    dispatch(argv)
+  rescue JiraTk::Pah::Error => e
+    warn e.message
+    exit 1
+  end
+
+  def dispatch(argv)
+    cmd = argv[0]
+    case cmd
+    when 'get' then cmd_get(argv[1])
+    when 'search' then cmd_search(argv[1..].join(' '))
+    when '-h', '--help', 'help', nil then usage(0)
+    else
+      warn "unknown command: #{cmd}"
+      usage(1)
+    end
+  end
+
+  def cmd_get(key)
+    abort_usage 'get requires PAH-<number>' if key.nil? || key.empty?
+
+    puts JSON.pretty_generate(JiraTk::Pah::Client.new.get(key))
+  end
+
+  def cmd_search(jql)
+    result = JiraTk::Pah::Client.new.search(jql.to_s)
+    puts JSON.pretty_generate(result)
+  end
+
+  def usage(exit_code = 0)
+    warn <<~USAGE
+      marisu-jira — PAH-only Jira reads for Marisu
+
+      Usage:
+        marisu-jira get PAH-<number>
+        marisu-jira search <jql fragment>
+        marisu-jira help
+
+      Search JQL is scoped to project = PAH automatically.
+      Credentials: DOOLIN_JIRA_ID, DOOLIN_JIRA_API
+    USAGE
+    exit exit_code
+  end
+
+  def abort_usage(message)
+    warn message
+    usage(1)
+  end
+end
+
+MarisuJiraCli.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/lib/jiratk/pah/client.rb
+++ b/lib/jiratk/pah/client.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module JiraTk
+  module Pah
+    # Jira read client for Marisu — PAH issues only.
+    class Client
+      BASE_URL = 'https://doolin.atlassian.net'
+      DEFAULT_FIELDS = 'summary,status,issuetype,components,parent,description'
+
+      def initialize(api_helper: nil, allowed_project: nil)
+        @allowed_project = allowed_project || Jql::PROJECT
+        unless @allowed_project == 'PAH'
+          raise Error, "Marisu client only supports PAH (got #{@allowed_project.inspect})"
+        end
+
+        @api = build_api(api_helper)
+      end
+
+      def get(issue_key, fields: DEFAULT_FIELDS)
+        key = IssueKey.validate!(issue_key)
+        url = "#{BASE_URL}/rest/api/3/issue/#{key}"
+        check_response!(parse(@api.get(url, { fields: fields })))
+      end
+
+      def search(user_jql, max_results: 50, fields: DEFAULT_FIELDS)
+        scoped = Jql.scope(user_jql)
+        { 'jql' => scoped, 'issues' => fetch_search_issues(scoped, max_results, fields) }
+      end
+
+      private
+
+      def build_api(api_helper)
+        return api_helper if api_helper
+
+        keys = AccountManager.new.api_keys
+        validate_credentials!(keys)
+        ApiHelper.new(keys[:jira_id], keys[:jira_key])
+      end
+
+      def fetch_search_issues(scoped, max_results, fields)
+        issues = []
+        token = nil
+        loop do
+          data = search_page(scoped, max_results, fields, token)
+          issues.concat(data['issues'] || [])
+          break if data['isLast']
+
+          token = data['nextPageToken']
+          break if token.nil? || token.empty?
+        end
+        issues
+      end
+
+      def search_page(scoped, max_results, fields, token)
+        params = { jql: scoped, maxResults: max_results, fields: fields }
+        params[:nextPageToken] = token if token
+        check_response!(parse(@api.get("#{BASE_URL}/rest/api/3/search/jql", params)))
+      end
+
+      def validate_credentials!(keys)
+        return if keys[:jira_id] && !keys[:jira_id].empty? && keys[:jira_key] && !keys[:jira_key].empty?
+
+        raise Error,
+              'Jira credentials missing. Set DOOLIN_JIRA_ID and DOOLIN_JIRA_API in the environment ' \
+              'where marisu-jira runs (Cursor agent / shell profile).'
+      end
+
+      def check_response!(body)
+        messages = body['errorMessages']
+        if messages.is_a?(Array) && !messages.empty?
+          hint = credentials_configured? ? messages.join('; ') : credential_hint
+          raise Error, hint
+        end
+
+        body
+      end
+
+      def credentials_configured?
+        keys = AccountManager.new.api_keys
+        keys[:jira_id] && !keys[:jira_id].empty? && keys[:jira_key] && !keys[:jira_key].empty?
+      end
+
+      def credential_hint
+        'Jira returned permission denied — usually missing DOOLIN_JIRA_ID / DOOLIN_JIRA_API ' \
+          'in this shell. Export them where Marisu runs marisu-jira.'
+      end
+
+      def parse(response)
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/lib/jiratk/pah/error.rb
+++ b/lib/jiratk/pah/error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module JiraTk
+  module Pah
+    class Error < StandardError; end
+  end
+end

--- a/lib/jiratk/pah/issue_key.rb
+++ b/lib/jiratk/pah/issue_key.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module JiraTk
+  module Pah
+    # Validates issue keys for Marisu (PAH-only reads).
+    class IssueKey
+      PATTERN = /\APAH-\d+\z/
+
+      def self.valid?(key)
+        key.is_a?(String) && key.match?(PATTERN)
+      end
+
+      def self.validate!(key)
+        raise Error, "issue key must be PAH-<number>, got: #{key.inspect}" unless valid?(key)
+
+        key
+      end
+    end
+  end
+end

--- a/lib/jiratk/pah/jql.rb
+++ b/lib/jiratk/pah/jql.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module JiraTk
+  module Pah
+    # Scopes JQL to the allowed project (PAH).
+    class Jql
+      PROJECT = ENV.fetch('JIRATK_ALLOWED_PROJECT', 'PAH').freeze
+
+      class << self
+        def scope(user_jql)
+          fragment = user_jql.to_s.strip
+          raise Error, 'JQL must not reference projects other than PAH' if references_other_project?(fragment)
+
+          return "project = #{PROJECT}" if fragment.empty?
+          return "project = #{PROJECT} #{fragment}" if order_by_only?(fragment)
+
+          "project = #{PROJECT} AND (#{fragment})"
+        end
+
+        def order_by_only?(jql)
+          jql.match?(/\AORDER\s+BY\b/i)
+        end
+
+        def references_other_project?(jql)
+          return false if jql.empty?
+
+          jql.match?(/\bproject\s*!=/i) ||
+            jql.match?(/\bproject\s*(?:not\s+)?in\s*\(/i) ||
+            jql.match?(/\bproject\s*=\s*["']?(?!#{PROJECT}\b)/i)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/jiratk/pah/client_spec.rb
+++ b/spec/lib/jiratk/pah/client_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/SpecFilePathFormat,RSpec/MultipleExpectations
+RSpec.describe JiraTk::Pah::Client do
+  let(:api) { instance_double(ApiHelper) }
+  let(:client) { described_class.new(api_helper: api) }
+
+  def api_response(body)
+    double(body: body)
+  end
+
+  describe '#get' do
+    it 'fetches a PAH issue' do
+      body = { 'key' => 'PAH-82' }.to_json
+      allow(api).to receive(:get).and_return(api_response(body))
+
+      expect(client.get('PAH-82')['key']).to eq('PAH-82')
+    end
+
+    it 'rejects GEN keys without calling the API' do
+      allow(api).to receive(:get)
+      expect { client.get('GEN-1') }.to raise_error(JiraTk::Pah::Error)
+      expect(api).not_to have_received(:get)
+    end
+  end
+
+  describe '#search' do
+    it 'searches with scoped JQL' do
+      body = { 'issues' => [], 'isLast' => true }.to_json
+      allow(api).to receive(:get).and_return(api_response(body))
+
+      result = client.search('status = Backlog')
+      expect(result['jql']).to eq('project = PAH AND (status = Backlog)')
+    end
+  end
+
+  describe 'allowed project' do
+    it 'rejects non-PAH allowed_project' do
+      expect { described_class.new(api_helper: api, allowed_project: 'GEN') }
+        .to raise_error(JiraTk::Pah::Error, /only supports PAH/)
+    end
+  end
+
+  describe 'credentials' do
+    it 'raises when credentials are missing' do
+      allow(AccountManager).to receive(:new)
+        .and_return(instance_double(AccountManager, api_keys: { jira_id: nil, jira_key: nil }))
+      expect { described_class.new }
+        .to raise_error(JiraTk::Pah::Error, /DOOLIN_JIRA_ID/)
+    end
+  end
+end
+# rubocop:enable RSpec/SpecFilePathFormat,RSpec/MultipleExpectations

--- a/spec/lib/jiratk/pah/issue_key_spec.rb
+++ b/spec/lib/jiratk/pah/issue_key_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe JiraTk::Pah::IssueKey do
+  describe '.valid?' do
+    it 'accepts PAH issue keys' do
+      expect(described_class.valid?('PAH-82')).to be true
+    end
+
+    it 'rejects GEN keys' do
+      expect(described_class.valid?('GEN-723')).to be false
+    end
+
+    it 'rejects PAH without a number' do
+      expect(described_class.valid?('PAH')).to be false
+    end
+
+    it 'rejects nil' do
+      expect(described_class.valid?(nil)).to be false
+    end
+  end
+
+  describe '.validate!' do
+    it 'raises for non-PAH keys' do
+      expect { described_class.validate!('GEN-1') }
+        .to raise_error(JiraTk::Pah::Error, /PAH-<number>/)
+    end
+  end
+end
+# rubocop:enable RSpec/SpecFilePathFormat

--- a/spec/lib/jiratk/pah/jql_spec.rb
+++ b/spec/lib/jiratk/pah/jql_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe JiraTk::Pah::Jql do
+  describe '.scope' do
+    it 'scopes empty JQL to project PAH' do
+      expect(described_class.scope('')).to eq('project = PAH')
+    end
+
+    it 'wraps a user fragment in project = PAH AND (...)' do
+      expect(described_class.scope('status = Backlog'))
+        .to eq('project = PAH AND (status = Backlog)')
+    end
+
+    it 'appends ORDER BY without illegal AND (...)' do
+      expect(described_class.scope('ORDER BY created DESC'))
+        .to eq('project = PAH ORDER BY created DESC')
+    end
+
+    it 'rejects JQL that targets another project' do
+      expect { described_class.scope('project = GEN') }
+        .to raise_error(JiraTk::Pah::Error, /other than PAH/)
+    end
+
+    it 'rejects project in (...)' do
+      expect { described_class.scope('project in (PAH, GEN)') }
+        .to raise_error(JiraTk::Pah::Error, /other than PAH/)
+    end
+  end
+end
+# rubocop:enable RSpec/SpecFilePathFormat

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,8 @@
 
 require 'vcr'
 
-Dir[File.join(File.dirname(__FILE__), '..', 'lib', 'jiratk', '**.rb')].each do |f|
-  require f
-end
+lib_root = File.expand_path('../lib/jiratk', __dir__)
+Dir[File.join(lib_root, '**', '*.rb')].each { |f| require f }
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'


### PR DESCRIPTION
## Summary
- `marisu-jira` CLI: PAH-only `get` and `search` (JSON stdout)
- `JiraTk::Pah::*` enforces `PAH-\d+` keys and scoped JQL
- Standalone via `bundler/inline` (rest-client only)

## Acceptance criteria
See [GEN-723](https://doolin.atlassian.net/browse/GEN-723) Acceptance Criteria field.

**Marisu runs:**
- [ ] `marisu-jira get PAH-1` → JSON
- [ ] `marisu-jira get GEN-723` → reject (exit 1)
- [ ] `marisu-jira search "status = Backlog"` → scoped JQL + issues
- [ ] `marisu-jira search "ORDER BY created DESC"` → ordered results
- [ ] Creds unset → clear error

**CI:** rspec + rubocop (automated)

https://doolin.atlassian.net/browse/GEN-723

[GEN-723]: https://doolin.atlassian.net/browse/GEN-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ