### PR TITLE
GEN-724 Add PAH-only transition commands to marisu-jira

### DIFF
--- a/exe/marisu_jira
+++ b/exe/marisu_jira
@@ -21,7 +21,34 @@ require 'jiratk/pah/issue_key'
 require 'jiratk/pah/jql'
 require 'jiratk/pah/client'
 
-# PAH-only Jira CLI for Marisu (reads).
+HELP_TEXT = <<~USAGE
+  marisu-jira — PAH-only Jira for Marisu
+
+  Usage:
+    marisu-jira get PAH-<number>
+    marisu-jira search <jql fragment>
+    marisu-jira transitions PAH-<number>
+    marisu-jira transition PAH-<number> --to "<status name>"
+    marisu-jira help
+
+  Reads:
+    get       Fetch one PAH issue (JSON).
+    search    Search PAH; JQL is scoped to project = PAH automatically.
+
+  Transitions:
+    transitions   List allowed status changes for a ticket (JSON). Run this
+                  first to see exact status names.
+    transition    Move a ticket to a new status. Names must match transitions
+                  output (case-insensitive).
+
+    When starting work on a ticket, move it to In Progress:
+      marisu-jira transition PAH-4 --to "In Progress"
+      marisu-jira get PAH-4
+
+  Credentials: DOOLIN_JIRA_ID, DOOLIN_JIRA_API
+USAGE
+
+# PAH-only Jira CLI for Marisu.
 module MarisuJiraCli
   module_function
 
@@ -32,17 +59,21 @@ module MarisuJiraCli
     exit 1
   end
 
+  # rubocop:disable Metrics/MethodLength
   def dispatch(argv)
     cmd = argv[0]
     case cmd
     when 'get' then cmd_get(argv[1])
     when 'search' then cmd_search(argv[1..].join(' '))
+    when 'transitions' then cmd_transitions(argv[1])
+    when 'transition' then cmd_transition(argv[1..])
     when '-h', '--help', 'help', nil then usage(0)
     else
       warn "unknown command: #{cmd}"
       usage(1)
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def cmd_get(key)
     abort_usage 'get requires PAH-<number>' if key.nil? || key.empty?
@@ -55,18 +86,32 @@ module MarisuJiraCli
     puts JSON.pretty_generate(result)
   end
 
+  def cmd_transitions(key)
+    abort_usage 'transitions requires PAH-<number>' if key.nil? || key.empty?
+
+    puts JSON.pretty_generate(JiraTk::Pah::Client.new.transitions(key))
+  end
+
+  def cmd_transition(args)
+    key, to = parse_transition_args(args)
+    puts JSON.pretty_generate(JiraTk::Pah::Client.new.transition(key, to: to))
+  end
+
+  def parse_transition_args(args)
+    key = args[0]
+    abort_usage 'transition requires PAH-<number>' if key.nil? || key.empty?
+
+    to_index = args.index('--to')
+    abort_usage 'transition requires --to "<status name>"' if to_index.nil?
+
+    to = args[(to_index + 1)..].join(' ').strip
+    abort_usage 'transition requires --to "<status name>"' if to.empty?
+
+    [key, to]
+  end
+
   def usage(exit_code = 0)
-    warn <<~USAGE
-      marisu-jira — PAH-only Jira reads for Marisu
-
-      Usage:
-        marisu-jira get PAH-<number>
-        marisu-jira search <jql fragment>
-        marisu-jira help
-
-      Search JQL is scoped to project = PAH automatically.
-      Credentials: DOOLIN_JIRA_ID, DOOLIN_JIRA_API
-    USAGE
+    warn HELP_TEXT
     exit exit_code
   end
 

--- a/lib/jiratk/api_helper.rb
+++ b/lib/jiratk/api_helper.rb
@@ -29,10 +29,12 @@ class ApiHelper
     )
   end
 
-  def post(url, params)
+  def post(url, params, debug: true)
     post_client(url, params).execute do |response, request, result, &block|
-      puts "RESPONSE: #{response.code}"
-      puts "RESPONSE BODY: #{response.body}"
+      if debug
+        puts "RESPONSE: #{response.code}"
+        puts "RESPONSE BODY: #{response.body}"
+      end
 
       return response if (200..499).include? response.code
 

--- a/lib/jiratk/pah/client.rb
+++ b/lib/jiratk/pah/client.rb
@@ -4,7 +4,8 @@ require 'json'
 
 module JiraTk
   module Pah
-    # Jira read client for Marisu — PAH issues only.
+    # Jira client for Marisu — PAH issues only.
+    # rubocop:disable Metrics/ClassLength
     class Client
       BASE_URL = 'https://doolin.atlassian.net'
       DEFAULT_FIELDS = 'summary,status,issuetype,components,parent,description'
@@ -29,7 +30,71 @@ module JiraTk
         { 'jql' => scoped, 'issues' => fetch_search_issues(scoped, max_results, fields) }
       end
 
+      def transitions(issue_key)
+        key = IssueKey.validate!(issue_key)
+        url = "#{BASE_URL}/rest/api/3/issue/#{key}/transitions"
+        check_response!(parse(@api.get(url, {})))
+      end
+
+      def transition(issue_key, to:)
+        target = to.to_s.strip
+        raise Error, 'transition requires --to "<status name>"' if target.empty?
+
+        match = resolve_transition(issue_key, target)
+        apply_transition(issue_key, match)
+      end
+
       private
+
+      def resolve_transition(issue_key, target)
+        data = transitions(issue_key)
+        list = data['transitions'] || []
+        match = find_transition(list, target)
+        raise Error, unavailable_transition_message(target, list) unless match
+
+        match
+      end
+
+      def apply_transition(issue_key, match)
+        key = IssueKey.validate!(issue_key)
+        url = "#{BASE_URL}/rest/api/3/issue/#{key}/transitions"
+        payload = { transition: { id: match['id'] } }
+        response = @api.post(url, payload, debug: false)
+        check_transition_response!(response, key, match)
+      end
+
+      def find_transition(list, name)
+        list.find { |t| t['name'].casecmp?(name) }
+      end
+
+      def unavailable_transition_message(name, list)
+        available = list.map { |t| t['name'] }.join(', ')
+        "No transition named #{name.inspect}. Available: #{available}"
+      end
+
+      def check_transition_response!(response, key, match)
+        code = response.code.to_i
+        raise Error, parse_post_error(response) unless (200..299).cover?(code)
+
+        {
+          'key' => key,
+          'transition' => match['name'],
+          'to' => match.dig('to', 'name')
+        }
+      end
+
+      def parse_post_error(response)
+        body = response.body.to_s
+        return "Transition failed (HTTP #{response.code})" if body.empty?
+
+        parsed = JSON.parse(body)
+        messages = parsed['errorMessages']
+        return messages.join('; ') if messages.is_a?(Array) && !messages.empty?
+
+        "Transition failed (HTTP #{response.code})"
+      rescue JSON::ParserError
+        "Transition failed (HTTP #{response.code})"
+      end
 
       def build_api(api_helper)
         return api_helper if api_helper
@@ -91,5 +156,6 @@ module JiraTk
         JSON.parse(response.body)
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/spec/lib/jiratk/pah/client_spec.rb
+++ b/spec/lib/jiratk/pah/client_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/SpecFilePathFormat,RSpec/MultipleExpectations
+# rubocop:disable RSpec/SpecFilePathFormat,RSpec/MultipleExpectations,RSpec/ExampleLength
 RSpec.describe JiraTk::Pah::Client do
   let(:api) { instance_double(ApiHelper) }
   let(:client) { described_class.new(api_helper: api) }
@@ -34,6 +34,68 @@ RSpec.describe JiraTk::Pah::Client do
     end
   end
 
+  describe '#transitions' do
+    it 'lists transitions for a PAH issue' do
+      body = { 'transitions' => [{ 'id' => '31', 'name' => 'In Progress' }] }.to_json
+      allow(api).to receive(:get).and_return(api_response(body))
+
+      result = client.transitions('PAH-4')
+      expect(result['transitions'].first['name']).to eq('In Progress')
+    end
+
+    it 'rejects GEN keys without calling the API' do
+      allow(api).to receive(:get)
+      expect { client.transitions('GEN-1') }.to raise_error(JiraTk::Pah::Error)
+      expect(api).not_to have_received(:get)
+    end
+  end
+
+  describe '#transition' do
+    let(:transition_list) do
+      {
+        'transitions' => [
+          { 'id' => '31', 'name' => 'In Progress', 'to' => { 'name' => 'In Progress' } }
+        ]
+      }.to_json
+    end
+
+    before { allow(api).to receive(:post) }
+
+    it 'applies a transition by name' do
+      allow(api).to receive_messages(
+        get: api_response(transition_list),
+        post: double(code: 204, body: '')
+      )
+
+      result = client.transition('PAH-4', to: 'In Progress')
+      expect(result).to eq(
+        'key' => 'PAH-4',
+        'transition' => 'In Progress',
+        'to' => 'In Progress'
+      )
+      expect(api).to have_received(:post).with(
+        'https://doolin.atlassian.net/rest/api/3/issue/PAH-4/transitions',
+        { transition: { id: '31' } },
+        debug: false
+      )
+    end
+
+    it 'rejects unknown transition names' do
+      allow(api).to receive(:get).and_return(api_response(transition_list))
+
+      expect { client.transition('PAH-4', to: 'Done') }
+        .to raise_error(JiraTk::Pah::Error, /No transition named/)
+      expect(api).not_to have_received(:post)
+    end
+
+    it 'rejects GEN keys without calling the API' do
+      allow(api).to receive(:get)
+      expect { client.transition('GEN-1', to: 'In Progress') }.to raise_error(JiraTk::Pah::Error)
+      expect(api).not_to have_received(:get)
+      expect(api).not_to have_received(:post)
+    end
+  end
+
   describe 'allowed project' do
     it 'rejects non-PAH allowed_project' do
       expect { described_class.new(api_helper: api, allowed_project: 'GEN') }
@@ -50,4 +112,4 @@ RSpec.describe JiraTk::Pah::Client do
     end
   end
 end
-# rubocop:enable RSpec/SpecFilePathFormat,RSpec/MultipleExpectations
+# rubocop:enable RSpec/SpecFilePathFormat,RSpec/MultipleExpectations,RSpec/ExampleLength


### PR DESCRIPTION
## Summary
- Add `transitions` and `transition --to` to `marisu-jira` (PAH-only, JSON stdout)
- Extend `JiraTk::Pah::Client` with status transitions resolved by name
- Help text documents list-then-transition workflow for starting work

## Motivation
Marisu should move PAH tickets when picking up work, still only through the gated CLI. Transition is the smallest first write and matches the workflow rule (ticket → In Progress).

## Marisu acceptance
- [ ] `marisu-jira transitions PAH-4` → lists transitions including In Progress
- [ ] `marisu-jira transition PAH-4 --to "In Progress"` → success JSON
- [ ] `marisu-jira get PAH-4` → status is In Progress
- [ ] `marisu-jira transition GEN-724 --to "In Progress"` → PAH key error, no API call

## Test plan
- [x] `bundle exec rspec spec/lib/jiratk/pah/`
- [x] `bundle exec rubocop lib/jiratk/pah exe/marisu_jira spec/lib/jiratk/pah`

https://doolin.atlassian.net/browse/GEN-724