### PR TITLE
GEN-726 Add comments read, [Marisu] prefix, and create to marisu-jira

### DIFF
--- a/exe/marisu_jira
+++ b/exe/marisu_jira
@@ -29,6 +29,7 @@ HELP_TEXT = <<~USAGE
     marisu-jira search <jql fragment>
     marisu-jira transitions PAH-<number>
     marisu-jira transition PAH-<number> --to "<status name>"
+    marisu-jira comment PAH-<number> "<text>"
     marisu-jira help
 
   Reads:
@@ -44,6 +45,12 @@ HELP_TEXT = <<~USAGE
     When starting work on a ticket, move it to In Progress:
       marisu-jira transition PAH-4 --to "In Progress"
       marisu-jira get PAH-4
+
+  Comments:
+    comment   Add a plain-text comment to a PAH ticket (JSON with comment id).
+              Quote text with spaces or special characters.
+
+      marisu-jira comment PAH-4 "Starting work — intern explanation"
 
   Credentials: DOOLIN_JIRA_ID, DOOLIN_JIRA_API
 USAGE
@@ -67,6 +74,7 @@ module MarisuJiraCli
     when 'search' then cmd_search(argv[1..].join(' '))
     when 'transitions' then cmd_transitions(argv[1])
     when 'transition' then cmd_transition(argv[1..])
+    when 'comment' then cmd_comment(argv[1..])
     when '-h', '--help', 'help', nil then usage(0)
     else
       warn "unknown command: #{cmd}"
@@ -108,6 +116,16 @@ module MarisuJiraCli
     abort_usage 'transition requires --to "<status name>"' if to.empty?
 
     [key, to]
+  end
+
+  def cmd_comment(args)
+    key = args[0]
+    abort_usage 'comment requires PAH-<number> and text' if key.nil? || key.empty?
+
+    text = args[1..].join(' ').strip
+    abort_usage 'comment requires PAH-<number> and text' if text.empty?
+
+    puts JSON.pretty_generate(JiraTk::Pah::Client.new.comment(key, text: text))
   end
 
   def usage(exit_code = 0)

--- a/exe/marisu_jira
+++ b/exe/marisu_jira
@@ -29,12 +29,15 @@ HELP_TEXT = <<~USAGE
     marisu-jira search <jql fragment>
     marisu-jira transitions PAH-<number>
     marisu-jira transition PAH-<number> --to "<status name>"
+    marisu-jira comments PAH-<number>
     marisu-jira comment PAH-<number> "<text>"
+    marisu-jira create --summary "<text>"
     marisu-jira help
 
   Reads:
     get       Fetch one PAH issue (JSON).
     search    Search PAH; JQL is scoped to project = PAH automatically.
+    comments  List comments on a PAH ticket (JSON).
 
   Transitions:
     transitions   List allowed status changes for a ticket (JSON). Run this
@@ -47,10 +50,17 @@ HELP_TEXT = <<~USAGE
       marisu-jira get PAH-4
 
   Comments:
-    comment   Add a plain-text comment to a PAH ticket (JSON with comment id).
-              Quote text with spaces or special characters.
+    comment   Add a plain-text comment (JSON with comment id). Text is
+              prefixed with [Marisu] automatically for audit trail.
+    comments  Read comments back after writing.
 
       marisu-jira comment PAH-4 "Starting work — intern explanation"
+      marisu-jira comments PAH-4
+
+  Create:
+    create    Open a new PAH Task (always project PAH; no override).
+
+      marisu-jira create --summary "Investigate serial buffer flush"
 
   Credentials: DOOLIN_JIRA_ID, DOOLIN_JIRA_API
 USAGE
@@ -66,7 +76,7 @@ module MarisuJiraCli
     exit 1
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
   def dispatch(argv)
     cmd = argv[0]
     case cmd
@@ -74,14 +84,16 @@ module MarisuJiraCli
     when 'search' then cmd_search(argv[1..].join(' '))
     when 'transitions' then cmd_transitions(argv[1])
     when 'transition' then cmd_transition(argv[1..])
+    when 'comments' then cmd_comments(argv[1])
     when 'comment' then cmd_comment(argv[1..])
+    when 'create' then cmd_create(argv[1..])
     when '-h', '--help', 'help', nil then usage(0)
     else
       warn "unknown command: #{cmd}"
       usage(1)
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
 
   def cmd_get(key)
     abort_usage 'get requires PAH-<number>' if key.nil? || key.empty?
@@ -118,6 +130,12 @@ module MarisuJiraCli
     [key, to]
   end
 
+  def cmd_comments(key)
+    abort_usage 'comments requires PAH-<number>' if key.nil? || key.empty?
+
+    puts JSON.pretty_generate(JiraTk::Pah::Client.new.comments(key))
+  end
+
   def cmd_comment(args)
     key = args[0]
     abort_usage 'comment requires PAH-<number> and text' if key.nil? || key.empty?
@@ -126,6 +144,21 @@ module MarisuJiraCli
     abort_usage 'comment requires PAH-<number> and text' if text.empty?
 
     puts JSON.pretty_generate(JiraTk::Pah::Client.new.comment(key, text: text))
+  end
+
+  def cmd_create(args)
+    summary = parse_summary_arg(args)
+    puts JSON.pretty_generate(JiraTk::Pah::Client.new.create(summary: summary))
+  end
+
+  def parse_summary_arg(args)
+    index = args.index('--summary')
+    abort_usage 'create requires --summary "<text>"' if index.nil?
+
+    summary = args[(index + 1)..].join(' ').strip
+    abort_usage 'create requires --summary "<text>"' if summary.empty?
+
+    summary
   end
 
   def usage(exit_code = 0)

--- a/lib/jiratk/pah/client.rb
+++ b/lib/jiratk/pah/client.rb
@@ -9,6 +9,8 @@ module JiraTk
     class Client
       BASE_URL = 'https://doolin.atlassian.net'
       DEFAULT_FIELDS = 'summary,status,issuetype,components,parent,description'
+      DEFAULT_ISSUETYPE = 'Task'
+      MARISU_COMMENT_PREFIX = '[Marisu] '
 
       def initialize(api_helper: nil, allowed_project: nil)
         @allowed_project = allowed_project || Jql::PROJECT
@@ -50,12 +52,39 @@ module JiraTk
 
         key = IssueKey.validate!(issue_key)
         url = "#{BASE_URL}/rest/api/3/issue/#{key}/comment"
-        payload = { body: adf_paragraph(body_text) }
+        payload = { body: adf_paragraph(marisu_comment_text(body_text)) }
         response = @api.post(url, payload, debug: false)
         parse_post_success!(response)
       end
 
+      def comments(issue_key)
+        key = IssueKey.validate!(issue_key)
+        url = "#{BASE_URL}/rest/api/3/issue/#{key}/comment"
+        check_response!(parse(@api.get(url, {})))
+      end
+
+      def create(summary:, issuetype: DEFAULT_ISSUETYPE)
+        summary_text = summary.to_s.strip
+        raise Error, 'create requires --summary' if summary_text.empty?
+
+        payload = {
+          fields: {
+            project: { key: Jql::PROJECT },
+            issuetype: { name: issuetype },
+            summary: summary_text
+          }
+        }
+        response = @api.post("#{BASE_URL}/rest/api/3/issue", payload, debug: false)
+        parse_post_success!(response)
+      end
+
       private
+
+      def marisu_comment_text(text)
+        return text if text.start_with?(MARISU_COMMENT_PREFIX.strip)
+
+        "#{MARISU_COMMENT_PREFIX}#{text}"
+      end
 
       def adf_paragraph(text)
         {

--- a/lib/jiratk/pah/client.rb
+++ b/lib/jiratk/pah/client.rb
@@ -44,7 +44,41 @@ module JiraTk
         apply_transition(issue_key, match)
       end
 
+      def comment(issue_key, text:)
+        body_text = text.to_s.strip
+        raise Error, 'comment requires text' if body_text.empty?
+
+        key = IssueKey.validate!(issue_key)
+        url = "#{BASE_URL}/rest/api/3/issue/#{key}/comment"
+        payload = { body: adf_paragraph(body_text) }
+        response = @api.post(url, payload, debug: false)
+        parse_post_success!(response)
+      end
+
       private
+
+      def adf_paragraph(text)
+        {
+          type: 'doc',
+          version: 1,
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: text }]
+            }
+          ]
+        }
+      end
+
+      def parse_post_success!(response)
+        code = response.code.to_i
+        raise Error, parse_post_error(response) unless (200..299).cover?(code)
+
+        body = response.body.to_s
+        return {} if body.empty?
+
+        check_response!(JSON.parse(body))
+      end
 
       def resolve_transition(issue_key, target)
         data = transitions(issue_key)
@@ -85,15 +119,15 @@ module JiraTk
 
       def parse_post_error(response)
         body = response.body.to_s
-        return "Transition failed (HTTP #{response.code})" if body.empty?
+        return "Request failed (HTTP #{response.code})" if body.empty?
 
         parsed = JSON.parse(body)
         messages = parsed['errorMessages']
         return messages.join('; ') if messages.is_a?(Array) && !messages.empty?
 
-        "Transition failed (HTTP #{response.code})"
+        "Request failed (HTTP #{response.code})"
       rescue JSON::ParserError
-        "Transition failed (HTTP #{response.code})"
+        "Request failed (HTTP #{response.code})"
       end
 
       def build_api(api_helper)

--- a/spec/lib/jiratk/pah/client_spec.rb
+++ b/spec/lib/jiratk/pah/client_spec.rb
@@ -115,11 +115,30 @@ RSpec.describe JiraTk::Pah::Client do
             content: [
               {
                 type: 'paragraph',
-                content: [{ type: 'text', text: 'Starting work' }]
+                content: [{ type: 'text', text: '[Marisu] Starting work' }]
               }
             ]
           }
         },
+        debug: false
+      )
+    end
+
+    it 'does not double-prefix Marisu comments' do
+      allow(api).to receive(:post).and_return(double(code: 201, body: comment_response))
+
+      client.comment('PAH-4', text: '[Marisu] already tagged')
+      expect(api).to have_received(:post).with(
+        anything,
+        hash_including(
+          body: hash_including(
+            content: [
+              hash_including(
+                content: [hash_including(text: '[Marisu] already tagged')]
+              )
+            ]
+          )
+        ),
         debug: false
       )
     end
@@ -133,6 +152,52 @@ RSpec.describe JiraTk::Pah::Client do
     it 'rejects GEN keys without calling the API' do
       allow(api).to receive(:post)
       expect { client.comment('GEN-1', text: 'nope') }.to raise_error(JiraTk::Pah::Error)
+      expect(api).not_to have_received(:post)
+    end
+  end
+
+  describe '#comments' do
+    it 'lists comments for a PAH issue' do
+      body = { 'comments' => [{ 'id' => '10001' }] }.to_json
+      allow(api).to receive(:get).and_return(api_response(body))
+
+      result = client.comments('PAH-4')
+      expect(result['comments'].first['id']).to eq('10001')
+    end
+
+    it 'rejects GEN keys without calling the API' do
+      allow(api).to receive(:get)
+      expect { client.comments('GEN-1') }.to raise_error(JiraTk::Pah::Error)
+      expect(api).not_to have_received(:get)
+    end
+  end
+
+  describe '#create' do
+    let(:create_response) do
+      { 'id' => '15200', 'key' => 'PAH-83', 'self' => 'https://doolin.atlassian.net/rest/api/3/issue/15200' }.to_json
+    end
+
+    it 'creates a PAH task' do
+      allow(api).to receive(:post).and_return(double(code: 201, body: create_response))
+
+      result = client.create(summary: 'New infra task')
+      expect(result['key']).to eq('PAH-83')
+      expect(api).to have_received(:post).with(
+        'https://doolin.atlassian.net/rest/api/3/issue',
+        {
+          fields: {
+            project: { key: 'PAH' },
+            issuetype: { name: 'Task' },
+            summary: 'New infra task'
+          }
+        },
+        debug: false
+      )
+    end
+
+    it 'rejects empty summary' do
+      allow(api).to receive(:post)
+      expect { client.create(summary: '  ') }.to raise_error(JiraTk::Pah::Error, /requires --summary/)
       expect(api).not_to have_received(:post)
     end
   end

--- a/spec/lib/jiratk/pah/client_spec.rb
+++ b/spec/lib/jiratk/pah/client_spec.rb
@@ -96,6 +96,47 @@ RSpec.describe JiraTk::Pah::Client do
     end
   end
 
+  describe '#comment' do
+    let(:comment_response) do
+      { 'id' => '10001', 'self' => 'https://doolin.atlassian.net/rest/api/3/issue/15199/comment/10001' }.to_json
+    end
+
+    it 'adds a comment to a PAH issue' do
+      allow(api).to receive(:post).and_return(double(code: 201, body: comment_response))
+
+      result = client.comment('PAH-4', text: 'Starting work')
+      expect(result['id']).to eq('10001')
+      expect(api).to have_received(:post).with(
+        'https://doolin.atlassian.net/rest/api/3/issue/PAH-4/comment',
+        {
+          body: {
+            type: 'doc',
+            version: 1,
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Starting work' }]
+              }
+            ]
+          }
+        },
+        debug: false
+      )
+    end
+
+    it 'rejects empty comment text' do
+      allow(api).to receive(:post)
+      expect { client.comment('PAH-4', text: '   ') }.to raise_error(JiraTk::Pah::Error, /requires text/)
+      expect(api).not_to have_received(:post)
+    end
+
+    it 'rejects GEN keys without calling the API' do
+      allow(api).to receive(:post)
+      expect { client.comment('GEN-1', text: 'nope') }.to raise_error(JiraTk::Pah::Error)
+      expect(api).not_to have_received(:post)
+    end
+  end
+
   describe 'allowed project' do
     it 'rejects non-PAH allowed_project' do
       expect { described_class.new(api_helper: api, allowed_project: 'GEN') }


### PR DESCRIPTION
## Summary

Extends `marisu-jira` for Marisu writes and read-back:

- **comment** — add comment (plain text → ADF, auto `[Marisu]` prefix)
- **comments** — list comments on a PAH ticket (closes verify loop)
- **create** — open PAH Task only (`--summary`, no project override)

## Motivation

GEN-726: Marisu acceptance showed POST works but `get` does not expand
comments; one-token model shows David Doolin as author — `[Marisu]`
prefix + `comments` read address both.

GEN-727: Marisu needs to file new PAH work without Ron or full jiratk.

## Ticket sync note

| Ticket | Status |
|--------|--------|
| GEN-724 | Done (manually set; GitHub-Jira lag after #108) |
| GEN-725 | Duplicate of GEN-726 |
| GEN-726 | This PR — comment + comments + prefix |
| GEN-727 | This PR — create |

## Marisu acceptance

**GEN-726**
- [x] `comment PAH-4` → JSON with id
- [ ] `comments PAH-4` → includes comment text
- [ ] New comments show `[Marisu]` prefix

**GEN-727**
- [ ] `create --summary "Marisu smoke test"` → PAH key JSON
- [ ] `get PAH-N` confirms summary

## Test plan

- [x] `bundle exec rspec spec/lib/jiratk/pah/` (28 examples)
- [x] `bundle exec rubocop`

https://doolin.atlassian.net/browse/GEN-726
https://doolin.atlassian.net/browse/GEN-727